### PR TITLE
feat: support wasm runtime

### DIFF
--- a/.github/workflows/test-rs.yml
+++ b/.github/workflows/test-rs.yml
@@ -26,15 +26,23 @@ jobs:
       - name: Setup clippy
         run: rustup component add clippy
       - name: Run clippy
-        run: cargo clippy --all-targets -- -D warnings
+        working-directory: og_image_writer
+        run: cargo clippy -- -D warnings
       - name: Run tests
+        working-directory: og_image_writer
         run: cargo test --verbose
       - name: Run snapshot test
         run: cargo make snapshots
       - name: Build
+        working-directory: og_image_writer
         run: cargo build --verbose
+      - name: Setup wasm32-wasi
+        run: rustup target add wasm32-wasi
+      - name: Build wasm for wasm runtime
+        working-directory: og_image_writer
+        run: cargo build --verbose --target wasm32-wasi
       - name: Setup wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Build wasm
+      - name: Build wasm for web
         working-directory: wasm
         run: wasm-pack build --target web

--- a/og_image_writer/Cargo.toml
+++ b/og_image_writer/Cargo.toml
@@ -11,20 +11,16 @@ description = "Generate an Open Graphic Image using a CSS-like API."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+web = ["dep:wasm-bindgen"]
+
 [dependencies]
 imageproc = "0.22"
 ab_glyph = "0.2.12"
 thiserror = "1.0"
-wasm-bindgen = { version = "=0.2.78" }
 conv = "0.3.3"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.image]
-version = "0.23"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.image]
-version = "0.23"
-default-features = false
-features = ["png", "jpeg"]
+wasm-bindgen = { version = "0.2.83", optional = true }
+image = { version = "0.23", default-features = false, features = ["png", "jpeg"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/og_image_writer/src/img.rs
+++ b/og_image_writer/src/img.rs
@@ -4,9 +4,20 @@ use super::style::BorderRadius;
 use image::{
     load_from_memory_with_format, open, DynamicImage, ImageBuffer, ImageError, ImageFormat, Rgba,
 };
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 use wasm_bindgen::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
+pub enum ImageInputFormat {
+    Png,
+    Jpeg,
+    // WebP,
+    // Avif,
+}
+
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 pub enum ImageInputFormat {
     Png,
     Jpeg,

--- a/og_image_writer/src/style.rs
+++ b/og_image_writer/src/style.rs
@@ -1,8 +1,18 @@
 pub use image::{Rgb, Rgba as ImageRgba};
 use std::marker::Copy;
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 use wasm_bindgen::prelude::*;
 
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
+#[derive(Debug, Copy, Clone)]
+pub enum KernSetting {
+    Normal,
+    Metrics,
+    Optical,
+}
+
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 #[derive(Debug, Copy, Clone)]
 pub enum KernSetting {
     Normal,
@@ -19,6 +29,7 @@ impl Rgba {
     }
 }
 
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
 #[derive(Debug, Copy, Clone)]
 pub enum WordBreak {
@@ -26,7 +37,22 @@ pub enum WordBreak {
     BreakAll,
 }
 
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+#[derive(Debug, Copy, Clone)]
+pub enum WordBreak {
+    Normal,
+    BreakAll,
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
+#[derive(Debug, Copy, Clone)]
+pub enum WhiteSpace {
+    Normal,
+    PreLine,
+}
+
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 #[derive(Debug, Copy, Clone)]
 pub enum WhiteSpace {
     Normal,
@@ -49,6 +75,7 @@ pub struct Margin(pub i32, pub i32, pub i32, pub i32);
 pub struct BorderRadius(pub u32, pub u32, pub u32, pub u32);
 
 /// Adjust the horizontal position.
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
 #[derive(Debug, Copy, Clone)]
 pub enum AlignItems {
@@ -57,7 +84,17 @@ pub enum AlignItems {
     End,
 }
 
+/// Adjust the horizontal position.
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+#[derive(Debug, Copy, Clone)]
+pub enum AlignItems {
+    Start,
+    Center,
+    End,
+}
+
 /// Adjust the vertical position.
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
 #[derive(Debug, Copy, Clone)]
 pub enum JustifyContent {
@@ -66,8 +103,26 @@ pub enum JustifyContent {
     End,
 }
 
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+/// Adjust the vertical position.
+#[derive(Debug, Copy, Clone)]
+pub enum JustifyContent {
+    Start,
+    Center,
+    End,
+}
+
 /// Adjust the text horizontal position.
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
+#[derive(Debug, Copy, Clone)]
+pub enum TextAlign {
+    Start,
+    Center,
+    End,
+}
+
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 #[derive(Debug, Copy, Clone)]
 pub enum TextAlign {
     Start,
@@ -82,6 +137,7 @@ pub enum TextOverflow {
     Content(String),
 }
 
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
 #[derive(Debug, Copy, Clone)]
 pub enum Position {
@@ -89,7 +145,22 @@ pub enum Position {
     Absolute,
 }
 
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+#[derive(Debug, Copy, Clone)]
+pub enum Position {
+    Static,
+    Absolute,
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[wasm_bindgen]
+#[derive(Debug, Copy, Clone)]
+pub enum FlexDirection {
+    Column,
+    Row,
+}
+
+#[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 #[derive(Debug, Copy, Clone)]
 pub enum FlexDirection {
     Column,

--- a/wasm/.cargo/config
+++ b/wasm/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target_arch = "wasm32"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,8 +15,8 @@ description = "Generate an Open Graphic Image using a CSS-like API."
 crate-type = ["cdylib"]
 
 [dependencies]
-og_image_writer = { path = "../og_image_writer" }
-wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
+og_image_writer = { path = "../og_image_writer", features = ["web"] }
+wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wee_alloc = { version = "0.4.5", optional = true }
 cfg-if = "1.0.0"


### PR DESCRIPTION
og_image_writer was supporting only wasm for web. But in a lot of case like fastly compute@edge, wasm runtime like wasmtime is used. Also wasm that is using `wam-bindgen` does not work on wasmtime. So I fixed to separate wasm to wasm for web and wasm for wasm runtime. 